### PR TITLE
Accept value from database for boolean 't' or 'f'

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -825,6 +825,11 @@ class FormBuilder
           return $checked;
       }
 
+      if ($value == 't')
+          $value = true;
+      if ($value == 'f')
+          $value = false;
+
       return $this->getValueAttribute($name) == $value;
   }
 


### PR DESCRIPTION
Radio button was not getting the old input from the database.  Here's a quick fix.